### PR TITLE
feat: Expose `essential-wallet-test` CLI with `test-utils` feature enabled

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -25,6 +25,7 @@
 
       packages = perSystemPkgs (pkgs: {
         essential-wallet = pkgs.essential-wallet;
+        essential-wallet-test = pkgs.essential-wallet-test;
         default = inputs.self.packages.${pkgs.system}.essential-wallet;
       });
 
@@ -37,6 +38,10 @@
         wallet = {
           type = "app";
           program = "${pkgs.essential-wallet}/bin/essential-wallet";
+        };
+        wallet-test = {
+          type = "app";
+          program = "${pkgs.essential-wallet-test}/bin/essential-wallet";
         };
         default = inputs.self.apps.${pkgs.system}.wallet;
       });

--- a/flake.nix
+++ b/flake.nix
@@ -41,7 +41,7 @@
         };
         wallet-test = {
           type = "app";
-          program = "${pkgs.essential-wallet-test}/bin/essential-wallet";
+          program = "${pkgs.essential-wallet-test}/bin/essential-wallet-test";
         };
         default = inputs.self.apps.${pkgs.system}.wallet;
       });

--- a/overlay.nix
+++ b/overlay.nix
@@ -4,5 +4,8 @@
   essential-wallet = prev.callPackage ./essential-wallet.nix { };
   essential-wallet-test = final.essential-wallet.overrideAttrs (finalAttr: prevAttr: {
     cargoBuildFeatures = [ "test-utils" ];
+    postInstall = ''
+      mv $out/bin/essential-wallet $out/bin/essential-wallet-test
+    '';
   });
 }

--- a/overlay.nix
+++ b/overlay.nix
@@ -2,4 +2,7 @@
 # into nixpkgs.
 {}: final: prev: {
   essential-wallet = prev.callPackage ./essential-wallet.nix { };
+  essential-wallet-test = final.essential-wallet.overrideAttrs (finalAttr: prevAttr: {
+    cargoBuildFeatures = [ "test-utils" ];
+  });
 }

--- a/shell.nix
+++ b/shell.nix
@@ -2,6 +2,7 @@
 { cargo-toml-lint
 , clippy
 , essential-wallet
+, essential-wallet-test
 , mkShell
 , rust-analyzer
 , rustfmt
@@ -11,6 +12,7 @@
 mkShell {
   inputsFrom = [
     essential-wallet
+    essential-wallet-test
   ];
   buildInputs = [
     cargo-toml-lint


### PR DESCRIPTION
This exposes a new `essential-wallet-test` package output from the flake. You can run it locally with:

```console
nix run .#essential-wallet-test -- --help
```

Test remotely with

```console
nix run github:essential-contributions/essential-wallet/mitchmindtree/wallet-test#essential-wallet-test -- --help
```